### PR TITLE
Allow for custom steam directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ for example, if you cloned the repo to your $HOME directory,
 ~/proton_aoe2de_mpfix/run.sh ; %command%
 ```
 
+You can pass an argument to the script to specify the location of steam on your device (default:/home/$USER/.local/share )
+
 ## Dependencies
 - cabextract
 - wget

--- a/run.sh
+++ b/run.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 set -e # Fail fast
 
-STEAM_LOCATION=/home/$USER/.local/share
+# check if we got an argument
+if [ $# -eq 0 ]; then
+# set STEAM_LOCATION to the provided argument
+	STEAM_LOCATION="$1"
+# else set STEAM_LOCATION to default
+else
+	STEAM_LOCATION="/home/$USER/.local/share"
+fi
 SYSTEM32_LOCATION=$STEAM_LOCATION/Steam/steamapps/compatdata/813780/pfx/drive_c/windows/system32
-
 # Check if the dll already exists and is not a symlink
 if [ -f "$SYSTEM32_LOCATION/ucrtbase.dll" ] && [ ! -L "$SYSTEM32_LOCATION/ucrtbase.dll" ]; then
     echo "ucrtbase.dll is already installed"


### PR DESCRIPTION
This fixes #1 
sometimes steam is installed in a different directory (like when installed by snap)